### PR TITLE
fix: exclude `react/jsx-runtime` from bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'jsxRuntime',
         },
         assetFileNames: 'styles/[name].[ext]',
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
before:
```
dist/index.js          39.18 kB │ gzip: 11.81 kB
dist/index.umd.cjs  26.25 kB │ gzip: 10.26 kB
```

after:
```
dist/index.js          18.00 kB │ gzip: 5.68 kB
dist/index.umd.cjs  12.70 kB │ gzip: 5.10 kB
```

So this halfs the bundle size.

Though note I'm not sure about the global for the UMD module, vite guessed something, but I personally use esm, so not sure how to go about it:
```
No name was provided for external module "react/jsx-runtime" in "output.globals" – guessing "jsxRuntime".
```