### PR TITLE
append time so it shows the right date in all timezones

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -69,7 +69,7 @@ export const getArraySum = (array: number[]): number => {
  * getDateTooltip('2023-07-08')
  */
 export const getDateTooltip = (dateString: string) => {
-  const date = getDateDetails(new Date(dateString))
+  const date = getDateDetails(new Date(dateString + 'T00:00'))
   return `${date.date}, ${date.month} ${date.day}, ${date.year}`
 }
 


### PR DESCRIPTION
Im in Brazil and because of the time zone offset, is returning yesterdays date.